### PR TITLE
使用Service Worker缓存页面并分流CDN

### DIFF
--- a/contest.html
+++ b/contest.html
@@ -14,6 +14,7 @@
 
 <body>
 	<script src="src/cont.js"></script>
+	<script src="src/swld.js"></script>
 	<div class="ui container">
 		<script>
 			window.onload = buildpage();

--- a/index.html
+++ b/index.html
@@ -29,9 +29,10 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/9000.0.1/themes/prism.min.css"
 		integrity="sha512-/mZ1FHPkg6EKcxo0fKXF51ak6Cr2ocgDi5ytaTBjsQZIH/RNs6GF6+oId/vPe3eJB836T36nXwVh/WBl/cWT4w=="
 		crossorigin="anonymous" referrerpolicy="no-referrer" />
-	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/9000.0.1/plugins/line-numbers/prism-line-numbers.min.css"
-	      integrity="sha512-3/cdM9qaJ5lBlzRKqwhMw+ZcNCVonz66BO6HgJudG/P1azm9wFrru31SsBa4T4Ew1AOH8HfDXSWS6emWwPl42A=="
-	      crossorigin="anonymous" referrerpolicy="no-referrer" />
+	<link rel="stylesheet"
+		href="https://cdnjs.cloudflare.com/ajax/libs/prism/9000.0.1/plugins/line-numbers/prism-line-numbers.min.css"
+		integrity="sha512-3/cdM9qaJ5lBlzRKqwhMw+ZcNCVonz66BO6HgJudG/P1azm9wFrru31SsBa4T4Ew1AOH8HfDXSWS6emWwPl42A=="
+		crossorigin="anonymous" referrerpolicy="no-referrer" />
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.3/katex.min.css"
 		integrity="sha512-6VMVcy7XQNyarhVuiL50FzpgCFKsyTd6YO93aaQEyET+BNaWvj0IgKR86Bf6+AmWczxAcSnL+JGjo+iStgO1gQ=="
 		crossorigin="anonymous" referrerpolicy="no-referrer" />
@@ -56,6 +57,7 @@
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/highcharts/10.2.1/modules/accessibility.min.js"
 		integrity="sha512-3v4MQPK+fT3z2i57H073Q3Emgd0TCeq+rvAFeDCd9vZ4VnYmtGU25LI5cni1ryxfHA8KDPg5MMTIqQLfabQlhA=="
 		crossorigin="anonymous"></script>
+	<script src="src/swld.js"></script>
 </head>
 
 <body class="dimmable">

--- a/src/func.js
+++ b/src/func.js
@@ -1390,9 +1390,9 @@ function getStatColor(stat) {
 function getStatClass(stat) {
 	if (stat == undefined)
 		return "";
-	if (stat.substr(0,2) == "AC")
+	if (stat.substr(0, 2) == "AC")
 		return "positive";
-	if (stat.substr(0,2) == "UA")
+	if (stat.substr(0, 2) == "UA")
 		return "negative";
 	return "";
 }
@@ -1453,7 +1453,7 @@ function importUser() {
 			}));
 		}
 		for (let i in usrPrbStat) {
-			if (getStatPriority(prbStat[i]) < getStatPriority(usrPrbStat[i])){
+			if (getStatPriority(prbStat[i]) < getStatPriority(usrPrbStat[i])) {
 				prbStat[i] = usrPrbStat[i];
 			}
 		}

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,0 +1,191 @@
+//d0j1a_1701 IntelligentCache&CDN sw.js Ver 1.5
+const CACHE_NAME = 'd0j1a1701Cache';
+let cachelist = [], whitelist = ['localhost', 'api.d0j1a1701.cc'];
+self.addEventListener('install', async function (installEvent) {
+    self.skipWaiting();
+    console.info('[Service Worker] Service Worker加载成功');
+    installEvent.waitUntil(
+        caches.open(CACHE_NAME)
+            .then(function (cache) {
+                console.info('[Service Worker] 缓存已加载');
+                return cache.addAll(cachelist);
+            })
+    );
+});
+self.addEventListener('fetch', async event => {
+    try {
+        event.respondWith(handle(event.request))
+    } catch (msg) {
+        event.respondWith(handleerr(event.request, msg))
+    }
+});
+const handleerr = async (req, msg) => {
+    return new Response(`<h1>Service Worker遇到了致命错误</h1><b>${msg}</b>`, { headers: { "content-type": "text/html; charset=utf-8" } })
+}
+let cdn = {
+    "gh": {
+        jsdelivr: {
+            "url": "https://cdn.jsdelivr.net/gh"
+        },
+        jsdelivr_fastly: {
+            "url": "https://fastly.jsdelivr.net/gh"
+        },
+        jsdelivr_gcore: {
+            "url": "https://gcore.jsdelivr.net/gh"
+        },
+        tianli: {
+            "url": "https://cdn1.tianli0.top/gh"
+        },
+        d0j1a1701: {
+            "url": "https://cdn.d0j1a1701.cc/gh"
+        }
+    },
+    "combine": {
+        jsdelivr: {
+            "url": "https://cdn.jsdelivr.net/combine"
+        },
+        jsdelivr_fastly: {
+            "url": "https://fastly.jsdelivr.net/combine"
+        },
+        jsdelivr_gcore: {
+            "url": "https://gcore.jsdelivr.net/combine"
+        },
+        d0j1a1701: {
+            "url": "https://cdn.d0j1a1701.cc/combine"
+        }
+    },
+    "npm": {
+        eleme: {
+            "url": "https://npm.elemecdn.com"
+        },
+        jsdelivr: {
+            "url": "https://cdn.jsdelivr.net/npm"
+        },
+        zhimg: {
+            "url": "https://unpkg.zhimg.com"
+        },
+        unpkg: {
+            "url": "https://unpkg.com"
+        },
+        bdstatic: {
+            "url": "https://code.bdstatic.com/npm"
+        },
+        tianli: {
+            "url": "https://cdn1.tianli0.top/npm"
+        },
+        sourcegcdn: {
+            "url": "https://npm.sourcegcdn.com/npm"
+        },
+        d0j1a1701: {
+            "url": "https://cdn.d0j1a1701.cc/npm"
+        }
+    }
+}
+const fetchFromCache = function (req) {
+    return new Promise(resolve => {
+        if (req.method == 'POST') {
+            resolve(fetch(req));
+            return;
+        }
+        let url = new URL(req.url), hostname = url.hostname;
+        if (whitelist.indexOf(hostname) != -1) {
+            resolve(fetch(req));
+            return;
+        }
+        setTimeout(async () => {
+            caches.match(req).then(function (resp) {
+                if (resp) {
+                    resolve(resp);
+                    fetch(req).then(function (res) {
+                        return caches.open(CACHE_NAME).then(function (cache) {
+                            cache.delete(req);
+                            cache.put(req, res.clone());
+                            return res;
+                        });
+                    });
+                } else {
+                    resolve(fetch(req).then(function (res) {
+                        return caches.open(CACHE_NAME).then(function (cache) {
+                            cache.delete(req);
+                            cache.put(req, res.clone());
+                            return res;
+                        });
+                    }));
+                }
+            })
+        }, 0)
+    });
+}
+const handle = async function (req) {
+    const urlStr = req.url
+    const domain = (urlStr.split('/'))[2]
+    let urls = []
+    //IntelligentCDN CDN分流器
+    for (let i in cdn) {
+        for (let j in cdn[i]) {
+            if (domain == cdn[i][j].url.split('https://')[1].split('/')[0] && urlStr.match(cdn[i][j].url)) {
+                urls = []
+                for (let k in cdn[i]) {
+                    urls.push(urlStr.replace(cdn[i][j].url, cdn[i][k].url))
+                }
+                if (urlStr.indexOf('@latest/') > -1) {
+                    return lfetch(urls, urlStr)
+                } else {
+                    return caches.match(req).then(function (resp) {
+                        return resp || lfetch(urls, urlStr).then(function (res) {
+                            return caches.open(CACHE_NAME).then(function (cache) {
+                                cache.put(req, res.clone());
+                                return res;
+                            });
+                        });
+                    })
+                }
+            }
+        }
+    }
+    //IntelligentCache
+    return fetchFromCache(req)
+}
+const lfetch = async (urls, url) => {
+    let controller = new AbortController();
+    const PauseProgress = async (res) => {
+        return new Response(await (res).arrayBuffer(), { status: res.status, headers: res.headers });
+    };
+    if (!Promise.any) {
+        Promise.any = function (promises) {
+            return new Promise((resolve, reject) => {
+                promises = Array.isArray(promises) ? promises : []
+                let len = promises.length
+                let errs = []
+                if (len === 0) return reject(new AggregateError('All promises were rejected'))
+                promises.forEach((promise) => {
+                    promise.then(value => {
+                        resolve(value)
+                    }, err => {
+                        len--
+                        errs.push(err)
+                        if (len === 0) {
+                            reject(new AggregateError(errs))
+                        }
+                    })
+                })
+            })
+        }
+    }
+    return Promise.any(urls.map(urls => {
+        return new Promise((resolve, reject) => {
+            fetch(urls, {
+                signal: controller.signal
+            })
+                .then(PauseProgress)
+                .then(res => {
+                    if (res.status == 200) {
+                        controller.abort();
+                        resolve(res)
+                    } else {
+                        reject(res)
+                    }
+                }).catch(err => { })
+        })
+    }))
+}

--- a/src/swld.js
+++ b/src/swld.js
@@ -1,3 +1,7 @@
 navigator.serviceWorker.register(`src/sw.js?time=${new Date().getTime()}`).then(async reg => {
-    window.location.search = `?time=${new Date().getTime()}`
+    if (window.localStorage.getItem('swinstall') != 'true') {
+        window.localStorage.setItem('swinstall', 'true');
+        window.location.search = `?time=${new Date().getTime()}`
+    }
+
 }).catch(err => { console.error(err); return; })

--- a/src/swld.js
+++ b/src/swld.js
@@ -1,0 +1,3 @@
+navigator.serviceWorker.register(`src/sw.js?time=${new Date().getTime()}`).then(async reg => {
+    window.location.search = `?time=${new Date().getTime()}`
+}).catch(err => { console.error(err); return; })


### PR DESCRIPTION
1. 极大加快外部资源的加载速度

2. 缓存打开过的页面，并在二次打开时优先调用缓存随后更新缓存，多次在几道题目间跳转时效果显著